### PR TITLE
Add waffle.io badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/kelsolaar/sibl_gui.png?label=ready&title=Ready 
+ :target: https://waffle.io/kelsolaar/sibl_gui
+ :alt: 'Stories in Ready'
 sIBL_GUI
 ========
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/kelsolaar/sibl_gui

This was requested by a real person (user KelSolaar) on waffle.io, we're not trying to spam you.
